### PR TITLE
Fix unexpected error fetching GitHub release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,8 @@
 name: Build
 
+permissions:
+  contents: write
+  
 on: [push, pull_request]
 
 jobs:


### PR DESCRIPTION
```
 Unexpected error fetching GitHub release for tag refs/tags/v2: HttpError: Resource not accessible by integration
```
![image](https://github.com/build-cpp/wdk_template/assets/13917777/966270f7-14c4-4521-9698-4aa8b405a1a8)

https://github.com/gmh5225/test-wdk_template/actions/runs/5340737794/jobs/9680882009